### PR TITLE
Add pdf viewer screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,5 +75,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
     implementation(libs.play.services.ads)
+    implementation(libs.androidPdfViewerLib)
 
 }

--- a/app/src/main/java/com/xsquare/documentscanner/data/IRepository.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/data/IRepository.kt
@@ -11,4 +11,6 @@ interface IRepository {
 
     suspend fun getDocuments(): List<Document>
 
+    suspend fun getDocument(id: Long): Document?
+
 }

--- a/app/src/main/java/com/xsquare/documentscanner/data/RepositoryImpl.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/data/RepositoryImpl.kt
@@ -19,4 +19,8 @@ class RepositoryImpl @Inject constructor(
         return localDataSource.fetchAll()
     }
 
+    override suspend fun getDocument(id: Long): Document? {
+        return localDataSource.fetchById(id)
+    }
+
 }

--- a/app/src/main/java/com/xsquare/documentscanner/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/data/local/LocalDataSource.kt
@@ -20,4 +20,8 @@ class LocalDataSource @Inject constructor(
         return documentDao.fetchAll()
     }
 
+    suspend fun fetchById(id: Long): Document? {
+        return documentDao.fetchById(id)
+    }
+
 }

--- a/app/src/main/java/com/xsquare/documentscanner/data/local/dao/DocumentDao.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/data/local/dao/DocumentDao.kt
@@ -19,4 +19,7 @@ abstract class DocumentDao {
     @Query("SELECT * FROM document")
     abstract suspend fun fetchAll(): List<Document>
 
+    @Query("SELECT * FROM document WHERE id = :id LIMIT 1")
+    abstract suspend fun fetchById(id: Long): Document?
+
 }

--- a/app/src/main/java/com/xsquare/documentscanner/navigation/DSNavigation.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/navigation/DSNavigation.kt
@@ -5,8 +5,11 @@ import androidx.lifecycle.ViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.xsquare.documentscanner.ui.screens.DocumentScreen
 import com.xsquare.documentscanner.ui.screens.WelcomeScreen
+import com.xsquare.documentscanner.ui.screens.PdfViewerScreen
 import com.xsquare.documentscanner.utils.LocalNavController
 import com.xsquare.documentscanner.viewmodel.MainViewModel
 
@@ -32,6 +35,13 @@ fun DSNavigation(viewModel: MainViewModel) {
             DocumentScreen(
                 viewModel = viewModel
             )
+        }
+        composable(
+            route = Screen.PdfViewer.route + "/{id}",
+            arguments = listOf(navArgument("id") { type = NavType.LongType })
+        ) { backStackEntry ->
+            val docId = backStackEntry.arguments?.getLong("id") ?: 0L
+            PdfViewerScreen(documentId = docId, viewModel = viewModel)
         }
     }
 }

--- a/app/src/main/java/com/xsquare/documentscanner/navigation/Screen.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/navigation/Screen.kt
@@ -8,4 +8,5 @@ sealed class Screen(val route: String) {
     data object WelcomeScreen: Screen("welcome_screen")
     data object DocumentScreen: Screen("docs_list_screen")
     data object ShareScreen: Screen("share")
+    data object PdfViewer: Screen("view_doc")
 }

--- a/app/src/main/java/com/xsquare/documentscanner/ui/components/DocumentCard.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/ui/components/DocumentCard.kt
@@ -32,13 +32,18 @@ import com.xsquare.documentscanner.utils.timestampToDate
  */
 
 @Composable
-fun DocumentCard(document: Document, onDocSettingsClick: (Document) -> Unit) {
+fun DocumentCard(
+    document: Document,
+    onDocClick: (Document) -> Unit,
+    onDocSettingsClick: (Document) -> Unit
+) {
     Column {
         Card(
             shape = RoundedCornerShape(8.dp),
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface
-            )
+            ),
+            modifier = Modifier.clickable { onDocClick(document) }
         ) {
             DocumentCardPreview(document)
             DocumentCardDetails(document, onDocSettingsClick)

--- a/app/src/main/java/com/xsquare/documentscanner/ui/screens/DocumentScreen.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/ui/screens/DocumentScreen.kt
@@ -61,6 +61,7 @@ import com.xsquare.documentscanner.ui.components.IconButton
 import com.xsquare.documentscanner.ui.components.ListItem
 import com.xsquare.documentscanner.ui.components.SearchBar
 import com.xsquare.documentscanner.utils.LocalActivity
+import com.xsquare.documentscanner.utils.LocalNavController
 import com.xsquare.documentscanner.utils.timestampToDate
 import com.xsquare.documentscanner.viewmodel.DocState
 import com.xsquare.documentscanner.viewmodel.MainViewModel
@@ -76,6 +77,7 @@ fun DocumentScreen(
     viewModel: MainViewModel
 ) {
     val activity = LocalActivity.current
+    val navController = LocalNavController.current
 
     var launchDocSettingsModal by remember {
         mutableStateOf(false)
@@ -250,7 +252,13 @@ private fun ColumnScope.DocsList(
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ){
             items(count = documents.size) { idx ->
-                DocumentCard(documents[idx], onDocSettingsClick)
+                DocumentCard(
+                    document = documents[idx],
+                    onDocClick = { doc ->
+                        navController.navigate(Screen.PdfViewer.route + "/${doc.id}")
+                    },
+                    onDocSettingsClick = onDocSettingsClick
+                )
             }
         }
     }

--- a/app/src/main/java/com/xsquare/documentscanner/ui/screens/PdfViewerScreen.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/ui/screens/PdfViewerScreen.kt
@@ -1,0 +1,32 @@
+package com.xsquare.documentscanner.ui.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.github.barteksc.pdfviewer.PDFView
+import com.xsquare.documentscanner.viewmodel.MainViewModel
+import java.io.File
+
+@Composable
+fun PdfViewerScreen(documentId: Long, viewModel: MainViewModel) {
+    var docPath by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(documentId) {
+        docPath = viewModel.getDocument(documentId)?.path
+    }
+
+    docPath?.let { path ->
+        AndroidView(factory = { context ->
+            PDFView(context, null).apply {
+                fromFile(File(path)).load()
+            }
+        }, update = { pdfView ->
+            pdfView.fromFile(File(path)).load()
+        }, modifier = Modifier)
+    }
+}

--- a/app/src/main/java/com/xsquare/documentscanner/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/xsquare/documentscanner/viewmodel/MainViewModel.kt
@@ -59,4 +59,8 @@ class MainViewModel @Inject constructor(
 
     }
 
+    suspend fun getDocument(id: Long): Document? {
+        return repository.getDocument(id)
+    }
+
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ roomKtx = "2.6.1"
 roomRuntime = "2.6.1"
 
 pdfium-android = "1.5.0"
+androidPdfViewer = "3.2.0-beta.1"
 
 [libraries]
 androidx-ktx = {module = "androidx.core:core-ktx", version.ref = "ktx"}
@@ -52,6 +53,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 
 pdfium-android = { group = "com.github.barteksc", name = "pdfium-android", version.ref = "pdfium-android" }
+androidPdfViewerLib = { group = "com.github.barteksc", name = "android-pdf-viewer", version.ref = "androidPdfViewer" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- add AndroidPdfViewer dependency
- open PdfViewerScreen on document tap
- wire navigation to PdfViewerScreen
- expose repository and DAO methods to load document by id

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684583b221f88332b7f9466b5f2adaa1